### PR TITLE
Respond to Exhibit-Related Changes by updating relevant DataStores

### DIFF
--- a/src/app/components/home-app/home-app.component.ts
+++ b/src/app/components/home-app/home-app.component.ts
@@ -5,12 +5,24 @@ import { MatSidenav } from '@angular/material/sidenav';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subject, Observable, BehaviorSubject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
-import { ComnSettingsService, Theme, ComnAuthQuery } from '@cmusei/crucible-common';
+import {
+  ComnSettingsService,
+  Theme,
+  ComnAuthQuery,
+} from '@cmusei/crucible-common';
 import { UserDataService } from 'src/app/data/user/user-data.service';
 import { TopbarView } from './../shared/top-bar/topbar.models';
 import { HealthCheckService } from 'src/app/generated/api';
-import { ApplicationArea, SignalRService } from 'src/app/services/signalr.service';
-import { Collection, Exhibit, Team, User } from 'src/app/generated/api/model/models';
+import {
+  ApplicationArea,
+  SignalRService,
+} from 'src/app/services/signalr.service';
+import {
+  Collection,
+  Exhibit,
+  Team,
+  User,
+} from 'src/app/generated/api/model/models';
 import { CollectionDataService } from 'src/app/data/collection/collection-data.service';
 import { CollectionQuery } from 'src/app/data/collection/collection.query';
 import { UserArticleDataService } from 'src/app/data/user-article/user-article-data.service';
@@ -32,7 +44,8 @@ import { XApiService } from 'src/app/generated/api';
 export class HomeAppComponent implements OnDestroy, OnInit {
   @ViewChild('sidenav') sidenav: MatSidenav;
   apiIsSick = false;
-  apiMessage = 'The GALLERY API web service appears to be experiencing technical difficulties.';
+  apiMessage =
+    'The GALLERY API web service appears to be experiencing technical difficulties.';
   titleText = 'Gallery';
   exhibitId = '';
   exhibit: Exhibit;
@@ -86,99 +99,131 @@ export class HomeAppComponent implements OnDestroy, OnInit {
     this.theme$ = this.authQuery.userTheme$;
     this.hideTopbar = this.inIframe();
     // subscribe to route changes
-    this.activatedRoute.queryParamMap.pipe(takeUntil(this.unsubscribe$)).subscribe(params => {
-      // exhibit and collection
-      const exhibitId = params.get('exhibit');
-      const collectionId = params.get('collection');
-      if (exhibitId) {
-        this.exhibitId = exhibitId;
-        this.exhibitDataService.loadById(exhibitId);
-        this.exhibitDataService.setActive(exhibitId);
-        this.uiDataService.setExhibit(exhibitId);
-        // section
-        this.selectedSection = params.get('section') as Section;
-        if (this.selectedSection) {
-          this.uiDataService.setSection(exhibitId, this.selectedSection);
-        } else {
-          this.selectedSection = this.uiDataService.getSection(exhibitId);
-        }
-        if (!this.selectedSection) {
-          this.selectedSection = Section.archive;
-          console.log('Section set to the default of archive');
-        }
-        this.loadExhibitData();
-      } else if (collectionId) {
-        this.exhibitId = '';
-        this.collectionId = collectionId;
-        this.loadCollectionData();
-      } else {
-        this.exhibitId = '';
-        this.collectionDataService.loadMine();
-      }
-      this.collectionDataService.setActive(this.collectionId);
-      // card
-      const cardId = params.get('card');
-      if (exhibitId && cardId) {
-        this.cardDataService.setActive(cardId);
-      }
-      // team
-      if (this.exhibitId && this.selectedTeamId) {
-        this.uiDataService.setTeam(exhibitId, this.selectedTeamId);
-        // xAPI
-        if (this.selectedTeamId !== this.teamDataService.getMyTeamId()) {
-          // observed
-          if (this.selectedSection === Section.archive) {
-            this.xApiService.observedExhibitArchive(this.exhibitId, this.selectedTeamId).pipe(take(1)).subscribe();
-          } else if (this.selectedSection === Section.wall) {
-            this.xApiService.observedExhibitWall(this.exhibitId, this.selectedTeamId).pipe(take(1)).subscribe();
+    this.activatedRoute.queryParamMap
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((params) => {
+        // exhibit and collection
+        const exhibitId = params.get('exhibit');
+        const collectionId = params.get('collection');
+        if (exhibitId) {
+          this.exhibitId = exhibitId;
+          this.exhibitDataService.loadById(exhibitId);
+          this.exhibitDataService.setActive(exhibitId);
+          this.uiDataService.setExhibit(exhibitId);
+          // section
+          this.selectedSection = params.get('section') as Section;
+          if (this.selectedSection) {
+            this.uiDataService.setSection(exhibitId, this.selectedSection);
+          } else {
+            this.selectedSection = this.uiDataService.getSection(exhibitId);
           }
+          if (!this.selectedSection) {
+            this.selectedSection = Section.archive;
+          }
+          this.loadExhibitData();
+        } else if (collectionId) {
+          this.exhibitId = '';
+          this.collectionId = collectionId;
+          this.loadCollectionData();
         } else {
-          // viewed
-          if (this.selectedSection === Section.archive) {
-            this.xApiService.viewedExhibitArchive(this.exhibitId).pipe(take(1)).subscribe();
-            if (cardId && cardId !== 'all') {
-              this.xApiService.viewedCard(this.exhibitId, cardId).pipe(take(1)).subscribe();
+          this.exhibitId = '';
+          this.collectionDataService.loadMine();
+        }
+        this.collectionDataService.setActive(this.collectionId);
+        // card
+        const cardId = params.get('card');
+        if (exhibitId && cardId) {
+          this.cardDataService.setActive(cardId);
+        }
+        // team
+        if (this.exhibitId && this.selectedTeamId) {
+          this.uiDataService.setTeam(exhibitId, this.selectedTeamId);
+          // xAPI
+          if (this.selectedTeamId !== this.teamDataService.getMyTeamId()) {
+            // observed
+            if (this.selectedSection === Section.archive) {
+              this.xApiService
+                .observedExhibitArchive(this.exhibitId, this.selectedTeamId)
+                .pipe(take(1))
+                .subscribe();
+            } else if (this.selectedSection === Section.wall) {
+              this.xApiService
+                .observedExhibitWall(this.exhibitId, this.selectedTeamId)
+                .pipe(take(1))
+                .subscribe();
             }
-          } else if (this.selectedSection === Section.wall) {
-            this.xApiService.viewedExhibitWall(this.exhibitId).pipe(take(1)).subscribe();
+          } else {
+            // viewed
+            if (this.selectedSection === Section.archive) {
+              this.xApiService
+                .viewedExhibitArchive(this.exhibitId)
+                .pipe(take(1))
+                .subscribe();
+              if (cardId && cardId !== 'all') {
+                this.xApiService
+                  .viewedCard(this.exhibitId, cardId)
+                  .pipe(take(1))
+                  .subscribe();
+              }
+            } else if (this.selectedSection === Section.wall) {
+              this.xApiService
+                .viewedExhibitWall(this.exhibitId)
+                .pipe(take(1))
+                .subscribe();
+            }
           }
         }
-      }
-    });
+      });
     // subscribe to the collections
-    this.collectionQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(collections => {
-      this.collectionList = collections;
-    });
+    this.collectionQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((collections) => {
+        this.collectionList = collections;
+      });
     // subscribe to the exhibits
-    this.exhibitQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(exhibits => {
-      this.exhibitList = exhibits;
-    });
+    this.exhibitQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((exhibits) => {
+        this.exhibitList = exhibits;
+      });
     // subscribe to the active exhibit
-    (this.exhibitQuery.selectActive() as Observable<Exhibit>).pipe(takeUntil(this.unsubscribe$)).subscribe(exhibit => {
-      if (exhibit && exhibit.id) {
-        this.exhibit = exhibit;
-        this.collectionId = this.exhibit.collectionId;
-        this.currentMove = this.exhibit.currentMove;
-        this.currentInject = this.exhibit.currentInject;
-      };
-    });
+    (this.exhibitQuery.selectActive() as Observable<Exhibit>)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((exhibit) => {
+        if (exhibit && exhibit.id) {
+          this.exhibit = exhibit;
+          this.collectionId = this.exhibit.collectionId;
+          this.currentMove = this.exhibit.currentMove;
+          this.currentInject = this.exhibit.currentInject;
+          this.handleExhibitMoveOrInjectChange();
+        }
+      });
     // subscribe to the user list
-    this.userDataService.userList.pipe(takeUntil(this.unsubscribe$)).subscribe(users => {
-      this.userList = users;
-    });
+    this.userDataService.userList
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((users) => {
+        this.userList = users;
+      });
     this.userDataService.getUsersFromApi();
     // subscribe to teams
-    this.teamQuery.selectAll().pipe(takeUntil(this.unsubscribe$)).subscribe(teams => {
-      this.teamList = teams;
-      this.setMyTeam();
-    });
+    this.teamQuery
+      .selectAll()
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((teams) => {
+        this.teamList = teams;
+        this.setMyTeam();
+      });
     // subscribe to the active team
-    (this.teamQuery.selectActive() as Observable<Team>).pipe(takeUntil(this.unsubscribe$)).subscribe(team => {
-      if (team && (!this.exhibit || this.exhibit.id !== team.id)) {
-        this.selectedTeamId = team.id;
-        this.loadTeamData();
-      };
-    });
+    (this.teamQuery.selectActive() as Observable<Team>)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((team) => {
+        if (team && (!this.exhibit || this.exhibit.id !== team.id)) {
+          this.selectedTeamId = team.id;
+          this.loadTeamData();
+        }
+      });
     // subscribe to the logged in user
     this.userDataService.loggedInUser
       .pipe(takeUntil(this.unsubscribe$))
@@ -201,7 +246,6 @@ export class HomeAppComponent implements OnDestroy, OnInit {
       ? this.settingsService.settings.AppTopBarHexTextColor
       : this.topbarTextColor;
     this.titleText = this.settingsService.settings.AppTopBarText;
-
   }
 
   ngOnInit() {
@@ -218,8 +262,8 @@ export class HomeAppComponent implements OnDestroy, OnInit {
 
   setMyTeam() {
     let myTeamId = '';
-    this.teamList.forEach(t => {
-      t.users.forEach(u => {
+    this.teamList.forEach((t) => {
+      t.users.forEach((u) => {
         if (u && u.id === this.loggedInUser.id) {
           myTeamId = t.id;
           this.teamDataService.setMyTeam(t.id);
@@ -261,12 +305,17 @@ export class HomeAppComponent implements OnDestroy, OnInit {
   }
 
   healthCheck() {
-    this.healthCheckService.getReadiness().pipe(take(1)).subscribe(healthReport => {
-      this.apiIsSick = false;
-    },
-    error => {
-      this.apiIsSick = true;
-    });
+    this.healthCheckService
+      .getReadiness()
+      .pipe(take(1))
+      .subscribe(
+        (healthReport) => {
+          this.apiIsSick = false;
+        },
+        (error) => {
+          this.apiIsSick = true;
+        }
+      );
   }
 
   loadCollectionData() {
@@ -287,8 +336,14 @@ export class HomeAppComponent implements OnDestroy, OnInit {
     // process the change
     if (this.selectedTeamId) {
       this.cardDataService.setActive('all');
-      this.teamCardDataService.loadByExhibitTeam(this.exhibitId, this.selectedTeamId);
-      this.userArticleDataService.loadByExhibitTeam(this.exhibitId, this.selectedTeamId);
+      this.teamCardDataService.loadByExhibitTeam(
+        this.exhibitId,
+        this.selectedTeamId
+      );
+      this.userArticleDataService.loadByExhibitTeam(
+        this.exhibitId,
+        this.selectedTeamId
+      );
     }
   }
 
@@ -298,14 +353,25 @@ export class HomeAppComponent implements OnDestroy, OnInit {
     this.loadCollectionData();
   }
 
+  handleExhibitMoveOrInjectChange() {
+    this.teamCardDataService.loadByExhibitTeam(
+      this.exhibitId,
+      this.selectedTeamId
+    );
+    this.userArticleDataService.loadByExhibitTeam(
+      this.exhibitId,
+      this.selectedTeamId
+    );
+  }
+
   getUserName(userId: string) {
-    const user = this.userList.find(u => u.id === userId);
+    const user = this.userList.find((u) => u.id === userId);
     return user ? user.name : ' ';
   }
 
   gotoAdmin() {
     this.router.navigate(['/admin'], {
-      queryParams: { exhibit: this.exhibitId }
+      queryParams: { exhibit: this.exhibitId },
     });
   }
 
@@ -330,7 +396,7 @@ export class HomeAppComponent implements OnDestroy, OnInit {
 
   applyFilter(filterValue: string) {
     this.filterString = filterValue.trim().toLowerCase();
-    this.exhibitList = this.exhibitList.filter(exhibit => {
+    this.exhibitList = this.exhibitList.filter((exhibit) => {
       const createdBy = this.getUserName(exhibit.createdBy).toLowerCase();
       return createdBy.includes(this.filterString);
     });

--- a/src/app/components/home-app/home-app.component.ts
+++ b/src/app/components/home-app/home-app.component.ts
@@ -221,8 +221,11 @@ export class HomeAppComponent implements OnDestroy, OnInit {
       .selectAll()
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe((teams) => {
-        this.teamList = teams;
-        this.setMyTeam();
+        // in the initial state, we need to set the team and register with signalr.
+        if (!this.selectedTeamId) {
+          this.teamList = teams;
+          this.setMyTeam();
+        }
       });
     // subscribe to the logged in user
     this.userDataService.loggedInUser
@@ -270,10 +273,10 @@ export class HomeAppComponent implements OnDestroy, OnInit {
         }
       });
     });
-    if (!this.teamQuery.getActiveId()) {
+    if (!this.teamQuery.getActiveId() || !this.selectedTeamId) {
       this.changeTeam(myTeamId);
+      this.uiDataService.setTeam(this.exhibitId, myTeamId);
     }
-    this.uiDataService.setTeam(this.exhibitId, myTeamId);
   }
 
   changeTeam(teamId: string) {

--- a/src/app/components/home-app/home-app.component.ts
+++ b/src/app/components/home-app/home-app.component.ts
@@ -194,10 +194,19 @@ export class HomeAppComponent implements OnDestroy, OnInit {
       .subscribe((exhibit) => {
         if (exhibit && exhibit.id) {
           this.exhibit = exhibit;
+          // only handle the changing of move or inject if they are both defined and have actually changed
+          const inIntialState =
+            this.currentMove === -1 || this.currentInject === -1;
+          const moveOrInjectChanged =
+            !inIntialState &&
+            (this.exhibit.currentMove !== this.currentMove ||
+              this.exhibit.currentInject !== this.currentInject);
           this.collectionId = this.exhibit.collectionId;
           this.currentMove = this.exhibit.currentMove;
           this.currentInject = this.exhibit.currentInject;
-          this.handleExhibitMoveOrInjectChange();
+          if (moveOrInjectChanged) {
+            this.handleExhibitMoveOrInjectChange();
+          }
         }
       });
     // subscribe to the user list
@@ -214,15 +223,6 @@ export class HomeAppComponent implements OnDestroy, OnInit {
       .subscribe((teams) => {
         this.teamList = teams;
         this.setMyTeam();
-      });
-    // subscribe to the active team
-    (this.teamQuery.selectActive() as Observable<Team>)
-      .pipe(takeUntil(this.unsubscribe$))
-      .subscribe((team) => {
-        if (team && (!this.exhibit || this.exhibit.id !== team.id)) {
-          this.selectedTeamId = team.id;
-          this.loadTeamData();
-        }
       });
     // subscribe to the logged in user
     this.userDataService.loggedInUser
@@ -271,8 +271,7 @@ export class HomeAppComponent implements OnDestroy, OnInit {
       });
     });
     if (!this.teamQuery.getActiveId()) {
-      this.selectedTeamId = myTeamId;
-      this.teamDataService.setActive(myTeamId);
+      this.changeTeam(myTeamId);
     }
     this.uiDataService.setTeam(this.exhibitId, myTeamId);
   }


### PR DESCRIPTION
Placed a hook in the HomeApp to update the TeamCard and UserArticle data stores when the move and inject change on the current exhibit. This allows the wall and archive views to update when the exhibit move and inject change.

Note that many of the changed lines are from applying Prettier formatting rules. The substantive change is the addition of the handleExhibitMoveOrInjectChange function and calling it when the selected exhibit is modified (because move and/or inject changed).

Related issue is CWDOE-1365