### PR TITLE
Fixed open in tab by using HTML docs baseURI so the deployed path is included in links.

### DIFF
--- a/src/app/components/archive/archive.component.ts
+++ b/src/app/components/archive/archive.component.ts
@@ -282,7 +282,12 @@ export class ArchiveComponent implements OnDestroy {
           if (result.useUrl) {
             window.open(userArticle.article.url);
           } else {
-            const url = location.origin + '/exhibit/' + this.exhibit.id + '/article/' + userArticle.articleId;
+            const url =
+              document.baseURI +
+              '/exhibit/' +
+              this.exhibit.id +
+              '/article/' +
+              userArticle.articleId;
             window.open(url);
           }
         }


### PR DESCRIPTION
Fixed this using the HTML doc's baseURI in the window.open links. I tried to find an idiomatic way to do this via the Angular router, but that did not seem to work. I believe that a routerLink directive would correctly take the base href setting in index.html into account, but it does not seem to when doing a call via ts code. For example, this code did not work:

``` 
  const urlTree = this.router.createUrlTree([
              '/exhibit',
              this.exhibit.id,
              'article',
              userArticle.articleId,
            ]);
  const url = this.router.serializeUrl(urlTree); 
  window.open(url);
```

My actual fix was borrowed from @sei-aschlackman:
```
  const url =
              document.baseURI +
              '/exhibit/' +
              this.exhibit.id +
              '/article/' +
              userArticle.articleId;
  window.open(url);
```

I tested this by changing my index.html to include
``` 
<base href="/myapp/">
```
I ran ng serve with the  --serve-path  argument to get it to serve at that path as well

```
ng serve  --serve-path /myapp/
```