### PR TITLE
Add missing development build configuration for localNPM support

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -78,11 +78,20 @@
                 }
               ]
             },
+            "development": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": {
+                "scripts": true,
+                "styles": true,
+                "vendor": true
+              },
+              "namedChunks": true
+            },
             "localNPM": {
               "tsConfig": "tsconfig.local-npm.json"
             }
-          },
-          "defaultConfiguration": ""
+          }
         },
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
@@ -90,9 +99,13 @@
             "port": 4723,
             "buildTarget": "gallery-ui:build"
           },
+          "defaultConfiguration": "development",
           "configurations": {
             "production": {
               "buildTarget": "gallery-ui:build:production"
+            },
+            "development": {
+              "buildTarget": "gallery-ui:build:development"
             },
             "localNPM": {
               "buildTarget": "gallery-ui:build:development,localNPM"


### PR DESCRIPTION
The localNPM serve target references build:development,localNPM but no development build configuration existed, causing build failures.