### PR TITLE
Bump crucible-common to 0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@angular/material": "^21.2.1",
         "@angular/platform-browser": "^21.2.1",
         "@angular/router": "^21.2.1",
-        "@cmusei/crucible-common": "0.7.2",
+        "@cmusei/crucible-common": "0.7.3",
         "@datorama/akita": "^8.0.0",
         "@datorama/akita-ng-router-store": "^7.0.0",
         "@datorama/akita-ngdevtools": "^7.0.0",
@@ -2818,9 +2818,8 @@
       }
     },
     "node_modules/@cmusei/crucible-common": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@cmusei/crucible-common/-/crucible-common-0.7.2.tgz",
-      "integrity": "sha512-wIxhKoylCBOmh/92TrZWoZkIZyDoqATHQKXLvOafKWoyBbB4D6oM78BoFdqu5mzDnOi5qQe2R2Dt1/dDptEwvg==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@cmusei/crucible-common/-/crucible-common-0.7.3.tgz",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.1"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/material": "^21.2.1",
     "@angular/platform-browser": "^21.2.1",
     "@angular/router": "^21.2.1",
-    "@cmusei/crucible-common": "0.7.2",
+    "@cmusei/crucible-common": "0.7.3",
     "@datorama/akita": "^8.0.0",
     "@datorama/akita-ng-router-store": "^7.0.0",
     "@datorama/akita-ngdevtools": "^7.0.0",

--- a/src/app/components/shared/name-dialog/name-dialog.component.html
+++ b/src/app/components/shared/name-dialog/name-dialog.component.html
@@ -10,7 +10,6 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   [submitDisabled]="!form.valid || !form.dirty"
   [guardUnsavedWork]="form.dirty"
   (submit)="onClick()"
-  (cancel)="onCancel()"
 >
   <div crucibleDialogContent [formGroup]="form">
     @if (message) {

--- a/src/app/components/shared/name-dialog/name-dialog.component.ts
+++ b/src/app/components/shared/name-dialog/name-dialog.component.ts
@@ -53,8 +53,4 @@ export class NameDialogComponent {
     };
     this.dialogRef.close(result);
   }
-
-  onCancel(): void {
-    this.dialogRef.close();
-  }
 }


### PR DESCRIPTION
## Summary

Bumps `@cmusei/crucible-common` from `0.7.2` to `0.7.3`.

**What 0.7.3 provides:**
- **Cancel now closes `crucible-dialog` via the injected `MatDialogRef` instead of a bare `mat-dialog-close` attribute.** Previously the bare attribute made Angular close with `''` (empty string) rather than `undefined`, which slipped past `result ?? {...}` and `!result.wasCancelled` guards — a cancelled dialog could be treated as a real result.
- **Loading-state layout fix**: the primary button's label and `<mat-progress-spinner>` are now wrapped and laid out as one centered inline-flex row, fixing the spinner dropping to its own line beneath the label text while `loading` is set.

**Impact on gallery.ui:**
- `NameDialogComponent.onCancel()`, which existed only to close the dialog with no result, is now redundant and has been removed along with its `(cancel)` binding — the shell's default Cancel button now does this automatically. This app's consumers don't rely on a `wasCancelled` payload, so no other code changes were needed.
