### PR TITLE
Title the card dialog by mode instead of always "Edit Card"

### DIFF
--- a/src/app/components/admin/admin-card-edit-dialog/admin-card-edit-dialog.component.html
+++ b/src/app/components/admin/admin-card-edit-dialog/admin-card-edit-dialog.component.html
@@ -4,7 +4,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
 -->
 
 <crucible-dialog
-  dialogTitle="Edit Card"
+  [dialogTitle]="data.card?.id ? 'Edit Card' : 'Add a Card'"
   [form]="form"
   submitLabel="Save"
   [submitDisabled]="!errorFree() || !form.dirty"


### PR DESCRIPTION
## The problem

`dialogTitle` is hardcoded to `"Edit Card"` in `admin-card-edit-dialog.component.html:7`, so **adding** a new card shows the edit title. Cosmetic, but user-visible on every card creation.

## How to reproduce

Administration → Collections → expand a collection → Cards → **Add Card**. The dialog is titled "Edit Card".

## The fix

Bind the title to the presence of `data.card.id`, matching the pattern the article, exhibit, and team-card edit dialogs already use.

## Verification

Builds clean. End-to-end coverage now asserts the "Add a Card" title; it deliberately did *not* assert a title before, since asserting "Edit Card" for an add would have enshrined the defect.
