### PR TITLE
Show the API's detail sentence on a failed Wall advance

### DIFF
--- a/src/app/components/wall/wall.component.ts
+++ b/src/app/components/wall/wall.component.ts
@@ -117,7 +117,7 @@ export class WallComponent implements OnDestroy {
         },
         error: (err) => {
           this.isAdvancing = false;
-          const message = err?.error?.Detail || err?.error?.title || 'Already at the last move/inject.';
+          const message = err?.error?.detail || err?.error?.title || 'Already at the last move/inject.';
           this.snackBar.open(message, 'OK', { duration: 5000 });
         }
       });


### PR DESCRIPTION
## The problem

```ts
const message = err?.error?.Detail || err?.error?.title || 'Already at the last move/inject.';
//                            ^ capital D
```

ASP.NET serializes `ProblemDetails` in **camelCase**, so `err.error.Detail` is always `undefined`, the expression falls through to `title`, and the snackbar reads just **"Cannot advance."** The descriptive sentence — the one actually worth showing — is unreachable.

## How to reproduce

Advance an exhibit that is already at its last move/inject. The API returns:

```json
{"title":"Cannot advance.","status":400,
 "detail":"Already at the last move/inject. There are no further moves or injects to advance to."}
```

The snackbar shows only `Cannot advance.`

## The fix

Read `err?.error?.detail`.

Re-grepped `src/app`: this is the **only** PascalCase `ProblemDetails` read in the codebase, so the fix is local. The C# side constructs `ProblemDetails` with PascalCase property names, but that is the CLR-side name, not the wire name — which is the trap that produced this.

## Verification

Builds clean. End-to-end coverage previously asserted `'Cannot advance.'` — the real behavior — with a comment explaining why; it now asserts the full `detail` sentence.
