### PR TITLE
Surface upload failures via snackbar in the collection and exhibit services

### DIFF
--- a/src/app/data/collection/collection-data.service.ts
+++ b/src/app/data/collection/collection-data.service.ts
@@ -11,6 +11,7 @@ import { Collection, CollectionService } from 'src/app/generated/api';
 import { map, take, tap } from 'rxjs/operators';
 import { BehaviorSubject, Observable, combineLatest, Subject } from 'rxjs';
 import { PermissionDataService } from '../permission/permission-data.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Injectable({
   providedIn: 'root',
@@ -36,6 +37,7 @@ export class CollectionDataService {
     private collectionQuery: CollectionQuery,
     private collectionService: CollectionService,
     private permissionDataService: PermissionDataService,
+    private snackBar: MatSnackBar,
     private router: Router,
     private activatedRoute: ActivatedRoute
   ) {
@@ -248,9 +250,11 @@ export class CollectionDataService {
         (collection) => {
           this.collectionStore.upsert(collection.id, collection);
         },
-        (error) => {
+        (err) => {
           this.collectionStore.setLoading(false);
           this.uploadProgress.next(0);
+          const message = err?.error?.detail || err?.error?.title || 'The uploaded file could not be processed.';
+          this.snackBar.open(message, 'OK', { duration: 5000 });
         }
       );
   }

--- a/src/app/data/exhibit/exhibit-data.service.ts
+++ b/src/app/data/exhibit/exhibit-data.service.ts
@@ -11,6 +11,7 @@ import { Exhibit, ExhibitService, ItemStatus } from 'src/app/generated/api';
 import { map, take, tap } from 'rxjs/operators';
 import { BehaviorSubject, Observable, combineLatest, Subject } from 'rxjs';
 import { HttpEventType, HttpResponse } from '@angular/common/http';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Injectable({
   providedIn: 'root',
@@ -35,6 +36,7 @@ export class ExhibitDataService {
     private exhibitStore: ExhibitStore,
     private exhibitQuery: ExhibitQuery,
     private exhibitService: ExhibitService,
+    private snackBar: MatSnackBar,
     private router: Router,
     private activatedRoute: ActivatedRoute
   ) {
@@ -307,9 +309,11 @@ export class ExhibitDataService {
         next: (exhibit) => {
           this.exhibitStore.upsert(exhibit.id, exhibit);
         },
-        error: () => {
+        error: (err) => {
           this.exhibitStore.setLoading(false);
           this.uploadProgress.next(0);
+          const message = err?.error?.detail || err?.error?.title || 'The uploaded file could not be processed.';
+          this.snackBar.open(message, 'OK', { duration: 5000 });
         }
       });
   }


### PR DESCRIPTION
## The problem

A user who uploads a bad file gets **no feedback at all** — no sheet, no snackbar, no dialog.

`uploadJson` in both data services handles errors with only `setLoading(false)` and `uploadProgress.next(0)`. Because the error is *handled* there, it never reaches Angular's global `ErrorHandler` — the only thing that opens the system-message sheet. The upload quietly does nothing.

## How to reproduce

Administration → Collections → **Upload Collection**, and pick a file containing `this is not json at all`. The API rejects it; the UI shows nothing.

## The fix

Open a `MatSnackBar` with the API's `ProblemDetails` `detail`/`title` (camelCase, matching the Wall advance handler), falling back to a generic sentence, using the same duration and config `wall.component.ts` already uses. `setLoading(false)` and `uploadProgress.next(0)` are preserved unchanged.

This pairs with the API change that turns these responses into a 400 with a useful title. They are in different repositories and either can merge first.

## Verification

Builds clean. End-to-end coverage asserts the snackbar text alongside the 400, using `.last()` because MatSnackBar briefly keeps two containers in the DOM during the exit animation.
