### PR TITLE
Guard null team names throughout the admin Teams list

### DIFF
--- a/src/app/components/admin/admin-teams/admin-teams.component.ts
+++ b/src/app/components/admin/admin-teams/admin-teams.component.ts
@@ -198,10 +198,9 @@ export class AdminTeamsComponent implements OnInit, OnDestroy {
     const isAsc = direction !== 'desc';
     switch (column) {
       case 'name':
-        return (
-          (a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1) *
-          (isAsc ? 1 : -1)
-        );
+        const aName = a.name ? a.name.toLowerCase() : '';
+        const bName = b.name ? b.name.toLowerCase() : '';
+        return (aName < bName ? -1 : 1) * (isAsc ? 1 : -1);
         break;
       case 'email':
         const aEmail = a.email ? a.email.toLowerCase() : '';

--- a/src/app/components/admin/admin-teams/admin-teams.component.ts
+++ b/src/app/components/admin/admin-teams/admin-teams.component.ts
@@ -209,10 +209,9 @@ export class AdminTeamsComponent implements OnInit, OnDestroy {
         return (aEmail < bEmail ? -1 : 1) * (isAsc ? 1 : -1);
         break;
       default:
-        return (
-          (a.shortName.toLowerCase() < b.shortName.toLowerCase() ? -1 : 1) *
-          (isAsc ? 1 : -1)
-        );
+        const aShort = a.shortName ? a.shortName.toLowerCase() : '';
+        const bShort = b.shortName ? b.shortName.toLowerCase() : '';
+        return (aShort < bShort ? -1 : 1) * (isAsc ? 1 : -1);
         break;
     }
   }

--- a/src/app/components/admin/admin-teams/admin-teams.component.ts
+++ b/src/app/components/admin/admin-teams/admin-teams.component.ts
@@ -175,11 +175,14 @@ export class AdminTeamsComponent implements OnInit, OnDestroy {
       });
       if (filteredTeams && filteredTeams.length > 0 && this.filterString) {
         const filterString = this.filterString.toLowerCase();
-        filteredTeams = filteredTeams.filter(
-          (a) =>
-            a.shortName.toLowerCase().includes(filterString) ||
-            a.name.toLowerCase().includes(filterString)
-        );
+        filteredTeams = filteredTeams.filter((a) => {
+          const aShortName = a.shortName ? a.shortName.toLowerCase() : '';
+          const aName = a.name ? a.name.toLowerCase() : '';
+          return (
+            aShortName.includes(filterString) ||
+            aName.includes(filterString)
+          );
+        });
       }
     }
     return filteredTeams;


### PR DESCRIPTION
> **3 commits**, one per call site. Each has a different trigger, so they are worth reading separately.

## The problem

Three unguarded `.toLowerCase()` call sites in `admin-teams.component.ts`, all the same defect class:

| Commit | Call site | Field |
|---|---|---|
| 1 | `sortTeams()` `default` case | `shortName` |
| 2 | `sortTeams()` `case 'name'` | `name` |
| 3 | `getFilteredTeams()` predicate | both |

`Team.Name` and `Team.ShortName` are both nullable, and the admin UI lets a team be created with only one of them, so any of the three throws `TypeError: Cannot read properties of null (reading 'toLowerCase')`.

Note the asymmetry that made this a *miss* rather than an oversight: the `email` case sitting between them **is** already null-guarded. The pattern was known.

**A crash here is not a silent empty list.** The `TypeError` reaches Angular's global `ErrorHandler`, which opens a modal bottom sheet naming the error and applies `aria-hidden` to the admin screen behind it — so every locator underneath the sheet breaks too.

## How to reproduce — three distinct triggers

- **Default sort:** `POST /api/teams` with a `name` and no `shortName` (accepted — 201, reads back `null`), then open Administration → Exhibits → expand the exhibit → **Exhibit Teams** with **two or more teams present**. The comparator only runs with two or more, so a single-team exhibit looks fine and adding a second one throws.
- **Name-column sort:** seed a team with a `shortName` and no `name`, then click the **Full Name** column header. A single click reaches it.
- **Filter:** seed either shape, then type any character into the search box. **Loading the panel is not enough** — the predicate is skipped entirely for an empty filter string.

Also reproduced independently as a cross-worker test flake: a team-management test passed when run serially but failed roughly 1-in-2 with two workers. `POST /api/teams` returned **201** and the new row still never rendered, because a sibling worker's null-`shortName` team landed in the shared team store and made this worker's list throw mid-render.

## The fix

Fall back to `''` when null before lowercasing, at all three sites — the idiom the `email` case already uses.

In the filter, `shortName` and `name` are tested as **separate OR branches** rather than one combined string. This matters for behavior, not just safety: a team with a null `name` must still lowercase its `shortName` and **match on that branch**. Only the name branch is neutralized to non-matching; it never throws and never short-circuits the shortName check.

## Scope of the impact, stated precisely

`getFilteredTeams` filters on `t.exhibitId === this.exhibitId` **before** sorting and filtering, so damage from this component is confined to the offending exhibit. A sibling panel — fixed in a later pull request in this stack — does *not* filter by exhibit and is genuinely collection-wide.

## Verification

Builds clean. Two new end-to-end tests, both verified to fail against the pre-fix bundle and pass after. The filter test types a search term specifically because the defect is unreachable without one — a test that merely loaded the panel would pass pre-fix.
