### PR TITLE
Stop My Exhibits rewriting each exhibit's remembered section

### DIFF
--- a/src/app/components/home-app/home-app.component.html
+++ b/src/app/components/home-app/home-app.component.html
@@ -58,7 +58,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
           <ng-container matColumnDef="name">
             <mat-header-cell *matHeaderCellDef mat-sort-header>Name</mat-header-cell>
             <mat-cell *matCellDef="let exhibit">
-              <a [routerLink]="['/']" [queryParams]="getQueryParams(exhibit.id)">
+              <a [routerLink]="['/']" [queryParams]="{ exhibit: exhibit.id, section: Section.archive }">
                 {{ exhibit.name }}
               </a>
             </mat-cell>

--- a/src/app/components/home-app/home-app.component.ts
+++ b/src/app/components/home-app/home-app.component.ts
@@ -99,6 +99,7 @@ export class HomeAppComponent implements OnDestroy, OnInit {
   permissions: SystemPermission[] = [];
   canViewAdministration = false;
   readonly SystemPermission = SystemPermission;
+  readonly Section = Section;
 
   get canManageCurrentExhibit(): boolean {
     if (!this.exhibitId) return false;
@@ -460,12 +461,6 @@ export class HomeAppComponent implements OnDestroy, OnInit {
     this.router.navigate(['/']).then(() => {
       window.location.reload();
     });
-  }
-
-  getQueryParams(exhibitId: string) {
-    const queryParams = { exhibit: exhibitId };
-    this.uiDataService.setSection(exhibitId, Section.archive);
-    return queryParams;
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
## The problem

Each exhibit's remembered section is silently overwritten just by rendering My Exhibits:

```ts
getQueryParams(exhibitId: string) {
  const queryParams = { exhibit: exhibitId };
  this.uiDataService.setSection(exhibitId, Section.archive);   // side effect during render
  return queryParams;
}
```

`home-app.component.html:61` calls this from a template binding, once per row (`[queryParams]="getQueryParams(exhibit.id)"`), so merely rendering the list rewrites every exhibit's remembered section in `localStorage['uiState']` — on every change-detection pass. That destroys the per-exhibit memory `gotoSection()` maintains: visit an exhibit's Wall, return home, and the exhibit is silently reset to `archive` without a click.

It is also an impure template binding: writing state during change detection is a defect in its own right.

## How to reproduce

Visit an exhibit's Wall and confirm the remembered section is `"wall"`. Return to the home page and **click nothing** — it has already been rewritten to `"archive"`.

## The fix

Remove the impure method and its `uiDataService` write, and inline a static object literal into the `[queryParams]` binding carrying `section: Section.archive` directly — matching the exact string `startup()` compares against. Added a `readonly Section` alias since the template needed the enum and none was exposed.

Per review, the destination stays the **Archive**, so the user-visible landing behavior is unchanged; the link now states it explicitly instead of relying on a side effect during render. What changes is that rendering My Exhibits no longer corrupts the remembered section of every exhibit in the list.

## Verification

Builds clean, as does the rest of the stack above this branch.
