### PR TITLE
Add trackBy to the admin Collections and Exhibits tables

### DIFF
--- a/src/app/components/admin/admin-collections/admin-collections.component.html
+++ b/src/app/components/admin/admin-collections/admin-collections.component.html
@@ -22,7 +22,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   </div>
   <div class="table-container">
     @if (!isLoading) {
-    <table mat-table [dataSource]="dataSource" matSort multiTemplateDataRows>
+    <table mat-table [dataSource]="dataSource" matSort [trackBy]="trackByFn" multiTemplateDataRows>
 
       <ng-container matColumnDef="actions">
         <th mat-header-cell *matHeaderCellDef>

--- a/src/app/components/admin/admin-collections/admin-collections.component.ts
+++ b/src/app/components/admin/admin-collections/admin-collections.component.ts
@@ -145,6 +145,10 @@ export class AdminCollectionsComponent implements OnDestroy, AfterViewInit {
     });
   }
 
+  trackByFn(index: number, item: Collection) {
+    return item.id;
+  }
+
   toggleExpand(collectionId: string) {
     this.expandedCollectionId =
       this.expandedCollectionId === collectionId ? null : collectionId;

--- a/src/app/components/admin/admin-exhibits/admin-exhibits.component.html
+++ b/src/app/components/admin/admin-exhibits/admin-exhibits.component.html
@@ -28,7 +28,7 @@ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for
   </div>
   <div class="table-container">
     @if (!isLoading && selectedCollectionId) {
-    <table mat-table [dataSource]="dataSource" matSort multiTemplateDataRows>
+    <table mat-table [dataSource]="dataSource" matSort [trackBy]="trackByFn" multiTemplateDataRows>
 
       <ng-container matColumnDef="actions">
         <th mat-header-cell *matHeaderCellDef>

--- a/src/app/components/admin/admin-exhibits/admin-exhibits.component.ts
+++ b/src/app/components/admin/admin-exhibits/admin-exhibits.component.ts
@@ -204,6 +204,10 @@ export class AdminExhibitsComponent implements OnDestroy {
     });
   }
 
+  trackByFn(index: number, item: Exhibit) {
+    return item.id;
+  }
+
   toggleExpand(exhibit: Exhibit) {
     this.canManageExpandedExhibit = false;
     const isExpanded = this.expandedExhibitId === exhibit.id;


### PR DESCRIPTION
> **2 commits**, one per table — Collections first, then Exhibits.

## The problem

Both admin tables rebuild every row on every store emission, collapsing any open detail sub-panel **mid-edit**.

On each `selectAll()` emission the component rebuilds its list from fresh object clones (`{ ...entity }`) and reassigns `dataSource.data`. With no `trackBy`, CdkTable's differ uses the ephemeral render-row wrapper as identity, so every row — including the `multiTemplateDataRows` detail row — registers as removed-then-added and is destroyed and recreated. The expanded detail lives behind `@if (element.id === expanded...Id)`, so it comes back **collapsed**.

| Commit | Table | Panels lost |
|---|---|---|
| 1 | Collections | Cards / Articles / Memberships |
| 2 | Exhibits | Teams / Card Teams / Article Teams / Observers / Memberships |

**The trigger is global, not per-row.** `CollectionHandler.cs:45` adds the collection broadcast group, and `MainHub.cs:143` puts *every* holder of the view-collections permission into it; `CardHandler` and `ArticleHandler` broadcast to the same group. So **one user's unrelated change collapses every other admin's open panel.**

## How to reproduce

Open a collection's Articles panel (or an exhibit's Teams panel). From another session, `POST` an **unrelated** collection or exhibit. The panel collapses.

Proven by tagging the live `<app-admin-articles>` DOM element and watching the tag disappear with the expanded-row count dropping to 0. An earlier hypothesis — a modal overlay hiding the panel — was disproved: eight of eight cancel loops were stable in isolation.

## The fix

`trackByFn` keyed on the entity `id`, bound via `[trackBy]` on each table. CdkTable's `trackBy` is a **single table-level input shared by all `matRowDef`s**, so one binding also covers the `expandedDetail` row definition.

Verified against the installed `@angular/cdk` source that this changes the diff from add-plus-remove to an identity change, which patches the existing view's `$implicit` instead of tearing it down.

Narrowing the SignalR broadcast would reduce the churn further, but `trackBy` alone fixes the collapse — and see the API pull request on duplicate card events for why exhibit-group addressing is not available.

## Verification

Builds clean. This defect is why the card and article tests wrapped panel interactions in re-open helpers plus `expect(...).toPass()`; those wrappers are now deleted, confirmed with two separate two-worker runs — the configuration whose cross-test interference they existed for. Plus one new test, verified to fail pre-fix.
