### PR TITLE
Scope Wall and Archive live updates to the active exhibit

### DIFF
--- a/src/app/data/team/team-data.service.ts
+++ b/src/app/data/team/team-data.service.ts
@@ -30,6 +30,19 @@ export class TeamDataService {
   private pageSize: Observable<number>;
   private pageIndex: Observable<number>;
   private myTeam = {} as Team;
+  // Which exhibit the store's contents were last successfully loaded for, or
+  // null if that is not known. Written only where the store is replaced
+  // wholesale. Lets SignalRService tell "team absent because it is foreign" from
+  // "team absent because the store describes another exhibit, failed to load, or
+  // was never loaded" without guessing from the contents. Deliberately not
+  // cleared while a load is in flight: it keeps naming the exhibit the current
+  // contents actually came from, so a re-entrant load for the exhibit already
+  // held does not blank it and open a window that accepts foreign events.
+  private _loadedExhibitId: string | null = null;
+
+  get loadedExhibitId(): string | null {
+    return this._loadedExhibitId;
+  }
 
   constructor(
     private teamStore: TeamStore,
@@ -139,9 +152,14 @@ export class TeamDataService {
       .subscribe(
         (teams) => {
           this.teamStore.set(teams);
+          this._loadedExhibitId = exhibitId;
         },
         (error) => {
+          // The load failed, so the now-empty store is an artifact of the
+          // failure, not evidence that the exhibit has no teams. Clear the
+          // marker so callers treat the store as unable to answer.
           this.teamStore.set([]);
+          this._loadedExhibitId = null;
         }
       );
   }
@@ -159,15 +177,21 @@ export class TeamDataService {
       .subscribe(
         (teams) => {
           this.teamStore.set(teams);
+          this._loadedExhibitId = exhibitId;
         },
         (error) => {
+          // The load failed, so the now-empty store is an artifact of the
+          // failure, not evidence that the exhibit has no teams. Clear the
+          // marker so callers treat the store as unable to answer.
           this.teamStore.set([]);
+          this._loadedExhibitId = null;
         }
       );
   }
 
   unload() {
     this.teamStore.set([]);
+    this._loadedExhibitId = null;
     this.setActive('');
   }
 

--- a/src/app/services/signalr.service.ts
+++ b/src/app/services/signalr.service.ts
@@ -187,12 +187,28 @@ export class SignalRService implements OnDestroy {
     });
   }
 
+  // A Team carries exhibitId, so keep foreign teams out of the store that
+  // isTeamCardInActiveExhibit resolves against. Accept when the exhibitId is
+  // absent, so a team that predates the field is never dropped.
+  private isTeamInActiveExhibit(team: Team): boolean {
+    if (!this.isScopedToActiveExhibit() || !team.exhibitId) {
+      return true;
+    }
+    return team.exhibitId === this.exhibitQuery.getActiveId();
+  }
+
   private addTeamHandlers() {
     this.hubConnection.on('TeamUpdated', (team: Team) => {
+      if (!this.isTeamInActiveExhibit(team)) {
+        return;
+      }
       this.teamDataService.updateStore(team);
     });
 
     this.hubConnection.on('TeamCreated', (team: Team) => {
+      if (!this.isTeamInActiveExhibit(team)) {
+        return;
+      }
       this.teamDataService.updateStore(team);
     });
 
@@ -229,10 +245,12 @@ export class SignalRService implements OnDestroy {
   }
 
   // A Card carries only collectionId, so it cannot be tied to a single exhibit.
-  // Scope it by the active exhibit's collection instead: the Wall/Archive load
-  // cards for the active exhibit's collection (CardService.GetByExhibitAsync
-  // filters on exhibit.CollectionId), so a card outside that collection can
-  // never belong in these stores.
+  // Scope it by the active exhibit's collection instead. This is looser than the
+  // Wall/Archive load, which goes through CardService.GetByExhibitTeamAsync and
+  // filters tc.Card.CollectionId == exhibit.CollectionId && tc.TeamId == teamId,
+  // but a card outside the collection can never belong in these stores, and one
+  // inside it with no matching TeamCard is already invisible to both
+  // wall.setShownCardList() and archive.setCardLists().
   private isCardInActiveExhibit(card: Card): boolean {
     if (!this.isScopedToActiveExhibit()) {
       return true;
@@ -241,15 +259,25 @@ export class SignalRService implements OnDestroy {
     return !activeExhibit || card.collectionId === activeExhibit.collectionId;
   }
 
-  // A TeamCard carries teamId, and the team store holds the active exhibit's
-  // teams (TeamDataService.loadMine(exhibitId)), so an unknown teamId belongs to
-  // a different exhibit. Only filter once the teams have actually loaded, so a
-  // TeamCard arriving before them is not dropped.
+  // A TeamCard carries only teamId, but a Team carries exhibitId, so resolve the
+  // team and compare that. Bare store membership is not safe on its own: the team
+  // store is shared with the admin Exhibits view (loadByExhibitId) and is never
+  // cleared on exhibit exit, so between setActive(B) and loadMine(B) resolving it
+  // can still hold exhibit A's teams.
   private isTeamCardInActiveExhibit(teamCard: TeamCard): boolean {
-    if (!this.isScopedToActiveExhibit() || this.teamQuery.getCount() === 0) {
+    if (!this.isScopedToActiveExhibit()) {
       return true;
     }
-    return this.teamQuery.hasEntity(teamCard.teamId);
+    const activeExhibitId = this.exhibitQuery.getActiveId();
+    const team = this.teamQuery.getEntity(teamCard.teamId);
+    if (team && team.exhibitId) {
+      // Authoritative: the team itself says which exhibit it belongs to.
+      return team.exhibitId === activeExhibitId;
+    }
+    // The team is unknown, or predates exhibitId. Absence only means "foreign" if
+    // the store has actually been loaded for the active exhibit; if it holds no
+    // team of the active exhibit it is empty or still stale, so accept.
+    return !this.teamQuery.hasEntity((t) => t.exhibitId === activeExhibitId);
   }
 
   private addCardHandlers() {

--- a/src/app/services/signalr.service.ts
+++ b/src/app/services/signalr.service.ts
@@ -263,7 +263,9 @@ export class SignalRService implements OnDestroy {
   // team and compare that. Bare store membership is not safe on its own: the team
   // store is shared with the admin Exhibits view (loadByExhibitId) and is never
   // cleared on exhibit exit, so between setActive(B) and loadMine(B) resolving it
-  // can still hold exhibit A's teams.
+  // can still hold exhibit A's teams. When the team cannot be resolved, defer to
+  // TeamDataService.loadedExhibitId, which records which exhibit the store's
+  // contents were actually loaded for, rather than inferring it from them.
   private isTeamCardInActiveExhibit(teamCard: TeamCard): boolean {
     if (!this.isScopedToActiveExhibit()) {
       return true;
@@ -275,9 +277,11 @@ export class SignalRService implements OnDestroy {
       return team.exhibitId === activeExhibitId;
     }
     // The team is unknown, or predates exhibitId. Absence only means "foreign" if
-    // the store has actually been loaded for the active exhibit; if it holds no
-    // team of the active exhibit it is empty or still stale, so accept.
-    return !this.teamQuery.hasEntity((t) => t.exhibitId === activeExhibitId);
+    // the store's contents are known to be exactly the active exhibit's teams,
+    // which is what loadedExhibitId records. Any other value - a different
+    // exhibit, or null while a load is in flight, failed or never ran - means the
+    // store cannot answer, so accept rather than drop a legitimate event.
+    return this.teamDataService.loadedExhibitId !== activeExhibitId;
   }
 
   private addCardHandlers() {

--- a/src/app/services/signalr.service.ts
+++ b/src/app/services/signalr.service.ts
@@ -19,16 +19,21 @@ import {
 } from 'src/app/generated/api';
 import { UserDataService } from 'src/app/data/user/user-data.service';
 import { UserArticleDataService } from '../data/user-article/user-article-data.service';
+import { UserArticleQuery } from 'src/app/data/user-article/user-article.query';
 import { ArticleDataService } from 'src/app/data/article/article-data.service';
 import { Card } from 'src/app/data/card/card.store';
 import { CardDataService } from 'src/app/data/card/card-data.service';
+import { CardQuery } from 'src/app/data/card/card.query';
 import { CollectionDataService } from 'src/app/data/collection/collection-data.service';
 import { CollectionMembershipDataService } from '../data/collection/collection-membership-data.service';
 import { ExhibitDataService } from 'src/app/data/exhibit/exhibit-data.service';
 import { ExhibitMembershipDataService } from '../data/exhibit/exhibit-membership-data.service';
+import { ExhibitQuery } from 'src/app/data/exhibit/exhibit.query';
 import { GroupMembershipDataService } from '../data/group/group-membership.service';
 import { TeamDataService } from 'src/app/data/team/team-data.service';
+import { TeamQuery } from 'src/app/data/team/team.query';
 import { TeamCardDataService } from 'src/app/data/team-card/team-card-data.service';
+import { TeamCardQuery } from 'src/app/data/team-card/team-card.query';
 import { TeamUserDataService } from '../data/team-user/team-user-data.service';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -54,16 +59,21 @@ export class SignalRService implements OnDestroy {
     private settingsService: ComnSettingsService,
     private articleDataService: ArticleDataService,
     private cardDataService: CardDataService,
+    private cardQuery: CardQuery,
     private collectionDataService: CollectionDataService,
     private collectionMembershipDataService: CollectionMembershipDataService,
     private exhibitDataService: ExhibitDataService,
     private exhibitMembershipDataService: ExhibitMembershipDataService,
+    private exhibitQuery: ExhibitQuery,
     private groupMembershipDataService: GroupMembershipDataService,
     private teamDataService: TeamDataService,
+    private teamQuery: TeamQuery,
     private teamCardDataService: TeamCardDataService,
+    private teamCardQuery: TeamCardQuery,
     private teamUserDataService: TeamUserDataService,
     private userDataService: UserDataService,
-    private userArticleDataService: UserArticleDataService
+    private userArticleDataService: UserArticleDataService,
+    private userArticleQuery: UserArticleQuery
   ) {
     this.authService.user$.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
       this.reconnect();
@@ -205,30 +215,88 @@ export class SignalRService implements OnDestroy {
     });
   }
 
+  // The hub addresses Card/TeamCard/UserArticle events to the recipient's *user*
+  // group, so a user who belongs to teams in several exhibits receives events for
+  // all of them. The Wall/Archive stores are flat and id-keyed, so an event from
+  // another exhibit would otherwise be upserted into the exhibit currently open.
+  // The admin area deliberately works across exhibits (it loads cards by
+  // collection), so these filters only apply outside it.
+  private isScopedToActiveExhibit(): boolean {
+    return (
+      this.applicationArea !== ApplicationArea.admin &&
+      !!this.exhibitQuery.getActiveId()
+    );
+  }
+
+  // A Card carries only collectionId, so it cannot be tied to a single exhibit.
+  // Scope it by the active exhibit's collection instead: the Wall/Archive load
+  // cards for the active exhibit's collection (CardService.GetByExhibitAsync
+  // filters on exhibit.CollectionId), so a card outside that collection can
+  // never belong in these stores.
+  private isCardInActiveExhibit(card: Card): boolean {
+    if (!this.isScopedToActiveExhibit()) {
+      return true;
+    }
+    const activeExhibit = this.exhibitQuery.getActive() as Exhibit;
+    return !activeExhibit || card.collectionId === activeExhibit.collectionId;
+  }
+
+  // A TeamCard carries teamId, and the team store holds the active exhibit's
+  // teams (TeamDataService.loadMine(exhibitId)), so an unknown teamId belongs to
+  // a different exhibit. Only filter once the teams have actually loaded, so a
+  // TeamCard arriving before them is not dropped.
+  private isTeamCardInActiveExhibit(teamCard: TeamCard): boolean {
+    if (!this.isScopedToActiveExhibit() || this.teamQuery.getCount() === 0) {
+      return true;
+    }
+    return this.teamQuery.hasEntity(teamCard.teamId);
+  }
+
   private addCardHandlers() {
     this.hubConnection.on('CardUpdated', (card: Card) => {
+      if (!this.isCardInActiveExhibit(card)) {
+        return;
+      }
       this.cardDataService.updateStore(card);
     });
 
     this.hubConnection.on('CardCreated', (card: Card) => {
+      if (!this.isCardInActiveExhibit(card)) {
+        return;
+      }
       this.cardDataService.updateStore(card);
     });
 
+    // A delete carries only an id. Removing an id the store never held is
+    // already a no-op, but Akita still emits a new state and every Wall/Archive
+    // subscriber recomputes, so skip it.
     this.hubConnection.on('CardDeleted', (id: string) => {
+      if (!this.cardQuery.hasEntity(id)) {
+        return;
+      }
       this.cardDataService.deleteFromStore(id);
     });
   }
 
   private addTeamCardHandlers() {
     this.hubConnection.on('TeamCardUpdated', (teamCard: TeamCard) => {
+      if (!this.isTeamCardInActiveExhibit(teamCard)) {
+        return;
+      }
       this.teamCardDataService.updateStore(teamCard);
     });
 
     this.hubConnection.on('TeamCardCreated', (teamCard: TeamCard) => {
+      if (!this.isTeamCardInActiveExhibit(teamCard)) {
+        return;
+      }
       this.teamCardDataService.updateStore(teamCard);
     });
 
     this.hubConnection.on('TeamCardDeleted', (id: string) => {
+      if (!this.teamCardQuery.hasEntity(id)) {
+        return;
+      }
       this.teamCardDataService.deleteFromStore(id);
     });
   }
@@ -279,18 +347,35 @@ export class SignalRService implements OnDestroy {
     });
   }
 
+  // A UserArticle carries its own exhibitId, so it can be scoped directly.
+  private isUserArticleInActiveExhibit(userArticle: UserArticle): boolean {
+    if (!this.isScopedToActiveExhibit()) {
+      return true;
+    }
+    return userArticle.exhibitId === this.exhibitQuery.getActiveId();
+  }
+
   private addUserArticleHandlers() {
     this.hubConnection.on('UserArticleUpdated', (userArticle: UserArticle) => {
+      if (!this.isUserArticleInActiveExhibit(userArticle)) {
+        return;
+      }
       this.userArticleDataService.setAsDates(userArticle);
       this.userArticleDataService.updateStore(userArticle);
     });
 
     this.hubConnection.on('UserArticleCreated', (userArticle: UserArticle) => {
+      if (!this.isUserArticleInActiveExhibit(userArticle)) {
+        return;
+      }
       this.userArticleDataService.setAsDates(userArticle);
       this.userArticleDataService.updateStore(userArticle);
     });
 
     this.hubConnection.on('UserArticleDeleted', (id: string) => {
+      if (!this.userArticleQuery.hasEntity(id)) {
+        return;
+      }
       this.userArticleDataService.deleteFromStore(id);
     });
   }


### PR DESCRIPTION
> **3 commits — please review them individually.** The second and third each *replace* the previous commit's decision rule, so the combined diff hides two approaches that were tried and found wrong in opposite directions. That history is the argument for the final rule.

## The problem

**High severity.** A user who belongs to two exhibits sees another exhibit's cards and articles appear in the one they are currently viewing — **live, without a refresh**. Unread counts are wrong as a result.

The API addresses these events to the recipient's **userId** group, so a user on teams in several exhibits receives events for all of them. (See the API pull request on duplicate card events for why it cannot address an exhibit group: connections join only the userId group, and exhibit-id groups are joined solely on reconnect.) The client handlers then upserted every payload into flat, id-keyed stores with **no exhibit check**.

The REST reads are correctly scoped (`UserArticleService.cs` filters on the exhibit), so a reload shows the right data — this is purely **client store hygiene**.

## How to reproduce

Two-tab probe. Read an article in exhibit A while tab 2 sits in a different exhibit:

```
tab2 before            ["Probe Article 1785342893025"]
tab2 after read-on-A    ["Probe Article 1785342893025","News Article 1"]
tab2 title              Gallery Archive (1)
```

Wall probe — a card created in another exhibit appears in the open one:

```
wall before  ["Test Card 1","Test Card 2","Test Card 3"]
wall after   ["Probe2 Card 1785343465210","Test Card 1","Test Card 2","Test Card 3"]
```

## Commit 1 — filter each payload by what it actually carries

The three event types carry different identifying fields, so this is not one uniform check:

| Event | Carries | Test |
|---|---|---|
| UserArticle | `exhibitId` | compare to the active exhibit id |
| Card | `collectionId` only | compare to the active exhibit's `collectionId` |
| TeamCard | `teamId` only | resolve against the team store |
| deletes | `id` only | drop ids the store never held |

Dropping unheld deletes matters: otherwise the store emits a state change that every Wall and Archive subscriber recomputes on. All of it is guarded by the application area not being admin, and by an exhibit actually being active, so the admin views keep their cross-exhibit live updates — they load cards by collection rather than by exhibit and never set an active exhibit.

**What was wrong with it.** The TeamCard branch tested "is this team in the store?", assuming the team store only ever holds the active exhibit's teams. **That invariant is breakable:** the store is never cleared on exhibit exit, and the admin Exhibits view writes the same store. Between activating exhibit B and its team load resolving, the store can still hold exhibit A's teams — it is non-empty, so the empty-store escape hatch does not fire, and the lookup returns false, **dropping a legitimate exhibit-B TeamCard.** It failed *closed*.

## Commit 2 — resolve the exhibit from the team itself

A team carries its own `exhibitId`, so resolve the team and compare that. When the team is known and has an `exhibitId` it is **authoritative**. Otherwise absence is only treated as foreign if the store actually holds a team of the active exhibit; if it does not, the store is empty or stale, so **accept**. Team create and update events are filtered on the same rule, so a foreign team cannot be re-injected into the store the predicate resolves against.

This commit also corrects a wrong comment from commit 1: the Wall and Archive load through `GetByExhibitTeamAsync`, which also filters on team — **not** `GetByExhibitAsync`. So the collection-level Card filter is *looser* than a reload rather than equal to it. That is harmless: a card with no matching TeamCard is already invisible to the Wall's shown-card list.

**What was still wrong with it.** The replacement heuristic — "does the store hold any team of the active exhibit?" — reads the wrong thing. The store is shared between the home page's load and the admin load, and is never cleared, so its *contents* are not a reliable statement about the active exhibit.

The case that actually bites is a **steady state, not a transient**: a team load that succeeded for the active exhibit and returned **no teams for this user** — an authoritative empty result, which the API gives a non-member — leaves the store empty, so the check is false, the store reads as "stale", and **every foreign TeamCard is accepted for as long as the user stays there.**

## Commit 3 — record what the store was loaded for

Record the fact directly instead of inferring it from contents. `TeamDataService` gains a `loadedExhibitId` marker, set where the store is replaced wholesale, and the fallback becomes `loadedExhibitId !== activeExhibitId`. The authoritative branch from commit 2 is untouched.

**Three deliberate decisions, each with a failure mode behind it:**

1. **A marker, not clearing the store on exhibit change.** Clearing shared state that the admin load also writes would make the admin Teams panel dependent on call ordering during row expansion.
2. **Set on success, cleared on error, cleared in `unload()`, untouched while a load is in flight.** The error-path clear is load-bearing: without it, a failed load following a successful one leaves the marker confident over an emptied store, and the predicate then rejects **every** TeamCard for that exhibit. Cleared means uncertain, and uncertain accepts.
3. **Not cleared when a load *starts*.** An earlier revision did. It was removed because the home page re-fires its load on every query-parameter emission — every Wall/Archive toggle and every card click — which opened a one-round-trip accept window for foreign TeamCards on essentially **every navigation**. And because collections are reusable across exhibits, a foreign TeamCard sharing a card id can flip a card onto the Wall, which matches on card id alone.

**What this deliberately does not do.** When the store describes some *other* exhibit, the predicate still **accepts**. The store genuinely cannot answer whether a team of the active exhibit exists, and commit 1 above is what happens when you guess: **uncertainty must accept.**

**Accepted cost:** a repeat load for the exhibit already held will, for one round trip, reject a TeamCard for a team created since the last load. That requires the TeamCard to arrive before the team's own create event, and the next update event heals it.

## Verification

Builds clean. Assertions this defect had forced open are restored: exact list text in the archive card filter, `.first()` calls dropped in two archive tests, and an exact count restored in the article-share test.

Plus one new test, the most intricate of the set — and worth knowing why. It asserts the foreign card event **arrives**. Without that assertion it passed against the buggy predicate, because the Wall looks TeamCards up by card id, so a leaked foreign TeamCard is invisible when there is no matching card in the store. "Fails before the fix" was necessary but not sufficient.
