### PR TITLE
Guard null team and card names in the Card Teams panel

### DIFF
--- a/src/app/components/admin/admin-team-cards/admin-team-cards.component.ts
+++ b/src/app/components/admin/admin-team-cards/admin-team-cards.component.ts
@@ -159,15 +159,17 @@ export class AdminTeamCardsComponent implements OnInit, OnDestroy {
     this.filterString = filterValue.trim().toLowerCase();
     this.filteredTeamCardList = this.teamCardList
       .filter((teamCard) => {
-        const teamName = this.getTeamName(teamCard.teamId).toLowerCase();
-        const cardName = this.getCardName(teamCard.cardId).toLowerCase();
+        const teamName = this.getTeamName(teamCard.teamId);
+        const cardName = this.getCardName(teamCard.cardId);
+        const teamNameLower = teamName ? teamName.toLowerCase() : '';
+        const cardNameLower = cardName ? cardName.toLowerCase() : '';
         return (
           (this.selectedTeamId === '' ||
             teamCard.teamId === this.selectedTeamId) &&
           (this.selectedCardId === '' ||
             teamCard.cardId === this.selectedCardId) &&
-          (teamName.includes(this.filterString) ||
-            cardName.includes(this.filterString))
+          (teamNameLower.includes(this.filterString) ||
+            cardNameLower.includes(this.filterString))
         );
       })
       .sort((a: TeamCard, b: TeamCard) =>
@@ -189,19 +191,17 @@ export class AdminTeamCardsComponent implements OnInit, OnDestroy {
     const isAsc = direction !== 'desc';
     switch (column) {
       case 'teamId':
-        return (
-          (this.getTeamName(a.teamId).toLowerCase() <
-          this.getTeamName(b.teamId).toLowerCase()
-            ? -1
-            : 1) * (isAsc ? 1 : -1)
-        );
+        const aTeamName = this.getTeamName(a.teamId);
+        const bTeamName = this.getTeamName(b.teamId);
+        const aTeamNameLower = aTeamName ? aTeamName.toLowerCase() : '';
+        const bTeamNameLower = bTeamName ? bTeamName.toLowerCase() : '';
+        return (aTeamNameLower < bTeamNameLower ? -1 : 1) * (isAsc ? 1 : -1);
       case 'cardId':
-        return (
-          (this.getCardName(a.cardId).toLowerCase() <
-          this.getCardName(b.cardId).toLowerCase()
-            ? -1
-            : 1) * (isAsc ? 1 : -1)
-        );
+        const aCardName = this.getCardName(a.cardId);
+        const bCardName = this.getCardName(b.cardId);
+        const aCardNameLower = aCardName ? aCardName.toLowerCase() : '';
+        const bCardNameLower = bCardName ? bCardName.toLowerCase() : '';
+        return (aCardNameLower < bCardNameLower ? -1 : 1) * (isAsc ? 1 : -1);
       case 'move':
         return (a.move < b.move ? -1 : 1) * (isAsc ? 1 : -1);
       case 'inject':


### PR DESCRIPTION
## The problem

Four unguarded `.toLowerCase()` call sites in `admin-team-cards.component.ts` — the `teamId` and `cardId` cases of `sortTeamCards()`, and the filter predicate — on the results of `getTeamName()` and `getCardName()`.

Both helpers return the found record's `name` verbatim, and both `Team.name` and `Card.name` are nullable with no `[Required]`, so both can return `null`.

**This is the widest scope of the set.** This component **never filters its lists by `exhibitId`** — it renders the global store, and the API returns every card in the *collection*. So one null-named team or card blanks that panel for **every exhibit in the collection**, not just its own. This change fixes the crash; the unscoped rendering is pre-existing and untouched.

## How to reproduce

Seed a team or a card with a null `name`, plus a TeamCard linking them. Open Administration → Exhibits and **expand the exhibit row.**

The crash fires on **row expansion alone**, before the Card Teams sub-panel is even opened, because `<app-admin-team-cards>` sits in the detail row's markup. The modal error sheet then applies `aria-hidden` to the page behind it.

## The fix

Guard each field independently at the four call sites — extract the helper result to a local, fall back to `''` when null, then compare — the same idiom as the admin-teams guards earlier in this stack.

**Why not guard inside the helpers.** That would change template interpolation. The helpers return `card ? card.name : ' '`, so a null name currently renders as empty; making them always return a string would display a **space** where null currently displays nothing. The helpers' contract is left unchanged.

**Resulting ordering, stated so a reviewer can object:** a null name and an empty-string name both sort to the top and are equal under the fallback; a *missing* team or card record (helper returns `' '`) sorts after them. For filtering, null and empty-string names both match only an empty filter string, and the `' '` case never matches any filter input.

## Verification

Builds clean. One new end-to-end test, which races the target against the error sheet and reports the sheet's text — a test asserting only "the list is empty" fails confusingly here.
